### PR TITLE
Update chrome driver version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,4 +2,4 @@
 python_version="3.9"
 
 [packages]
-chromedriver-py="=123.0.6312.105"
+chromedriver-py="=124.0.6367.60"


### PR DESCRIPTION
Soluciona error en el job **UPDATE_3PARTY_RPMS**:
`[ERROR] /var/develenv/repositories/releases/24.7.100/el8/rc/3party/google-chrome-stable-124.0.6367.60-1.x86_64.rpm and /var/develenv/repositories/releases/24.7.100/el8/rc/3party/ss-develenv-selenium-38-4.10.0.123.0.6312.105.76.g8634857.el8.x86_64.rpm are incompatible. Create a pull request in https://github.com/softwaresano/develenv-selenium repository modifying chromedriver_version at Pipfile`