### PR TITLE
Update chrome driver version to v127

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,4 +2,4 @@
 python_version="3.9"
 
 [packages]
-chromedriver-py="=126.0.6478.55"
+chromedriver-py="=127.0.6533.72"


### PR DESCRIPTION
**Update3party log**:

```
03:50:18  [ERROR] /var/develenv/repositories/releases/24.7.100/el8/rc/3party/google-chrome-stable-127.0.6533.72-1.x86_64.rpm and /var/develenv/repositories/releases/24.7.100/el8/rc/3party/ss-develenv-selenium-38-4.10.0.126.0.6478.55.83.g7ef0a8b.el8.x86_64.rpm are incompatible. Create a pull request in https://github.com/softwaresano/develenv-selenium repository modifying chromedriver_version at Pipfile
```

Test slave de OPTDEV:
```
Notice: /Stage[main]/Tests_slave/Exec[Google Chrome Compatibility]/returns: [2024-07-24 06:56:10] [ERROR] Google Chrome 127.0.6533.72  is incompatible with ChromeDriver 126.0.6478.55 (7616ff175414646cbd1ac65e912fc530b19cc573-refs/branch-heads/6478@{#1402})
Error: '/opt/p2pcdn/bin/google-chrome-compatibility.sh' returned 1 instead of one of [0]
Error: /Stage[main]/Tests_slave/Exec[Google Chrome Compatibility]/returns: change from 'notrun' to ['0'] failed: '/opt/p2pcdn/bin/google-chrome-compatibility.sh' returned 1 instead of one of [0]
```
