### PR TITLE
Update chromedriver version

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -36,7 +36,7 @@ jobs:
           git checkout ${{github.head_ref}}
           ./update.sh && ./build.sh
       - name: Upload artifact
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: Binary RPM
           path: target/rpm

--- a/Pipfile
+++ b/Pipfile
@@ -2,4 +2,4 @@
 python_version="3.9"
 
 [packages]
-chromedriver-py="=127.0.6533.119"
+chromedriver-py="=130.0.6723.58"


### PR DESCRIPTION
`03:50:59  [ERROR] /var/develenv/repositories/releases/24.11.100/el8/rc/3party/google-chrome-stable-130.0.6723.58-1.x86_64.rpm and /var/develenv/repositories/releases/24.11.100/el8/rc/3party/ss-develenv-selenium-38-4.10.0.127.0.6533.119.89.g9978a1c.el8.x86_64.rpm are incompatible. Create a pull request in https://github.com/softwaresano/develenv-selenium repository modifying chromedriver_version at Pipfile`