### PR TITLE
new chrome version 131

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,4 +2,4 @@
 python_version="3.9"
 
 [packages]
-chromedriver-py="=130.0.6723.58"
+chromedriver-py="=131.0.6778.69"


### PR DESCRIPTION
`02:50:09  [ERROR] /var/develenv/repositories/releases/24.11.100/el8/rc/3party/google-chrome-stable-131.0.6778.69-1.x86_64.rpm and /var/develenv/repositories/releases/24.11.100/el8/rc/3party/ss-develenv-selenium-38-4.10.0.130.0.6723.58.92.gf3c86b8.el8.x86_64.rpm are incompatible. Create a pull request in https://github.com/softwaresano/develenv-selenium repository modifying chromedriver_version at Pipfile`