### PR TITLE
update to v145

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -2,4 +2,4 @@
 python_version="3.9"
 
 [packages]
-chromedriver-py="=144.0.7559.59"
+chromedriver-py="=145.0.7632.45"


### PR DESCRIPTION
`'[ERROR] /var/develenv/repositories/releases/26.4.100/el8/rc/3party/google-chrome-stable-145.0.7632.45-1.x86_64.rpm and /var/develenv/repositories/releases/26.4.100/el8/rc/3party/ss-develenv-selenium-38-4.10.0.144.0.7559.59.127.g539336a.el8.x86_64.rpm are incompatible. Create a pull request in https://github.com/softwaresano/develenv-selenium repository modifying chromedriver_version at Pipfile'`